### PR TITLE
Added line break to Discord Nitro Scams

### DIFF
--- a/wiki/resources/tools/phishing.md
+++ b/wiki/resources/tools/phishing.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 # Phishing Related
 
 ### **Discord Nitro Scams**
-> __Description:__ This **safe and secure** website (*not a scam*) compares real Discord Nitro gifts to scams. Beware!
+> __Description:__ This **safe and secure** website (*not a scam*) compares real Discord Nitro gifts to scams. Beware!   <br/>
 __Link:__ [Discord Nitro Information](https://dicsord.gq/)
 
 ### **Virus Total**


### PR DESCRIPTION
In my last change, I added formatting to the Discord Nitro Scams website, as previously is was thrown at the top of the page. I forgot to add the <br/>. Oops!